### PR TITLE
initial support for default grafana-influxdb datasource, dashboard and additional plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Docker StatsD InfluxDB Grafana image
 -----------------------------------
 
+## v1.0.2 (2016-09-15)
+
+* Fix for bad proxy hash sum mismatch
+
 ## v1.0.1 (2016-06-27)
 
 * Upgraded StatsD to version 0.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN apt-get -y --force-yes install\
  libfontconfig\
  mysql-client\
  mysql-server\
- net-tools
+ net-tools\
+ netcat
 
 # Create support directories
 RUN mkdir -p /etc/my_init.d
@@ -87,6 +88,8 @@ RUN wget https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_a
 	dpkg -i grafana_${GRAFANA_VERSION}_amd64.deb && rm grafana_${GRAFANA_VERSION}_amd64.deb
 
 # Configure Grafana
+ADD scripts/setup_grafana.sh /tmp/setup_grafana.sh
+RUN /tmp/setup_grafana.sh
 ADD grafana/grafana.ini /etc/grafana/grafana.ini
 ADD grafana/run.sh /etc/my_init.d/04_run_grafana.sh
 
@@ -96,6 +99,9 @@ ADD system/bashrc /root/.bashrc
 # Cleanup
 RUN apt-get clean\
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ # Add dashboards
+ADD grafana/*.json /var/lib/grafana/dashboards/
 
 # Create volumes
 VOLUME /var/log

--- a/grafana/docker.json
+++ b/grafana/docker.json
@@ -1,0 +1,550 @@
+{
+  "id": null,
+  "title": "Docker",
+  "originalTitle": "Docker",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "decimals": null,
+          "editable": true,
+          "error": false,
+          "fill": 2,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "leftYAxisLabel": "",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "rightYAxisLabel": "",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "target": "alias(stats.timers.$Application.$Host.docker-cpu.$Image.percent-cpu-usage.mean_99, 'Cpu Percent')",
+              "textEditor": false
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "transparent": true,
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "percent",
+            "short"
+          ]
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 2,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 8,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(stats.timers.$Application.$Host.docker-network.$Image.rx-bytes.sum, 'sum'), 'Received')",
+              "textEditor": true
+            },
+            {
+              "target": "alias(consolidateBy(stats.timers.$Application.$Host.docker-network.$Image.tx-bytes.sum, 'sum'), 'Transmitted')",
+              "textEditor": true
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Network Traffic",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "transparent": true,
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "bytes",
+            "short"
+          ]
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "id": 3,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "hide": false,
+              "target": "consolidateBy(stats.timers.$Application.$Host.docker-network.$Image.rx-errors.sum, 'sum')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "",
+          "title": "RX-Errors",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "id": 4,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "target": "consolidateBy(stats.timers.$Application.$Host.docker-network.$Image.rx-dropped.sum, 'sum')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "",
+          "title": "RX-Dropped",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "id": 5,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "target": "consolidateBy(stats.timers.$Application.$Host.docker-network.$Image.tx-errors.sum, 'sum')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "",
+          "title": "TX-Errors",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "id": 6,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "target": "consolidateBy(stats.timers.$Application.$Host.docker-network.$Image.tx-dropped.sum, 'sum')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "",
+          "title": "TX-Dropped",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 2,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 7,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "target": "alias(consolidateBy(stats.timers.$Application.$Host.docker-memory.$Image.usage.sum, 'sum'), 'Usage')",
+              "textEditor": true
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Memory",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "transparent": true,
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "bytes",
+            "short"
+          ]
+        }
+      ],
+      "title": "New row"
+    }
+  ],
+  "nav": [
+    {
+      "collapse": false,
+      "enable": true,
+      "notice": false,
+      "now": true,
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "type": "timepicker"
+    }
+  ],
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "allFormat": "glob",
+        "current": {
+          "text": "kamon",
+          "value": "kamon"
+        },
+        "datasource": null,
+        "includeAll": false,
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "Application",
+        "options": [
+          {
+            "selected": true,
+            "text": "kamon",
+            "value": "kamon"
+          }
+        ],
+        "query": "stats.timers.*",
+        "refresh_on_load": false,
+        "type": "query"
+      },
+      {
+        "allFormat": "glob",
+        "current": {
+          "text": "home_compu",
+          "value": "home_compu",
+          "tags": []
+        },
+        "datasource": null,
+        "includeAll": false,
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "Host",
+        "options": [
+          {
+            "selected": true,
+            "text": "home_compu",
+            "value": "home_compu"
+          }
+        ],
+        "query": "stats.timers.*.*",
+        "refresh_on_load": false,
+        "type": "query"
+      },
+      {
+        "allFormat": "glob",
+        "current": {
+          "text": "awesome-image",
+          "value": "awesome-image"
+        },
+        "datasource": null,
+        "includeAll": false,
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "Image",
+        "options": [
+          {
+            "selected": true,
+            "text": "awesome-image",
+            "value": "awesome-image"
+          }
+        ],
+        "query": "stats.timers.*.*.*.*",
+        "refresh_on_load": false,
+        "type": "query"
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": "10s",
+  "schemaVersion": 6,
+  "version": 10,
+  "links": []
+}

--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -21,7 +21,7 @@
 #
 # Directory where grafana will automatically scan and look for plugins
 #
-;plugins = /var/lib/grafana/plugins
+plugins = /var/lib/grafana/plugins
 
 #
 #################################### Server ####################################
@@ -290,8 +290,8 @@ admin_password = root
 
 ;#################################### Dashboard JSON files ##########################
 [dashboards.json]
-;enabled = false
-;path = /var/lib/grafana/dashboards
+enabled = true
+path = /var/lib/grafana/dashboards
 
 #################################### Internal Grafana Metrics ##########################
 # Metrics available at HTTP API Url /api/metrics

--- a/scripts/setup_grafana.sh
+++ b/scripts/setup_grafana.sh
@@ -1,0 +1,82 @@
+#!/bin/bash -e
+
+function check_grafana_connection {
+  while ! nc -z localhost 3000 < /dev/null; do   
+        sleep 1;
+    done
+}
+
+function grafana_check_data_source {
+  check_grafana_connection
+  curl --silent  'http://admin:admin@localhost:3000/api/datasources' \
+    | grep "{\"name\":\"${INFLUXDB_GRAFANA_DB}\"}" --silent
+}
+
+function grafana_create_data_source {
+  check_grafana_connection
+  curl --silent 'http://admin:admin@localhost:3000/api/datasources' \
+    -X POST -H "Content-Type: application/json" \
+    --data-binary \
+      "{
+        \"name\":\"influxdb\",
+        \"type\":\"influxdb\",
+        \"url\":\"http://localhost:8086\",
+        \"access\":\"proxy\",
+        \"isDefault\":true,
+        \"basicAuth\":false,
+        \"database\":\"'${INFLUXDB_GRAFANA_DB}'\",
+        \"user\":\"\",
+        \"password\":\"\",
+        \"jsonData\":null
+      }" 2>&1 | grep 'Datasource added' --silent
+}
+
+function setup_grafana {
+  if grafana_check_data_source "${INFLUXDB_GRAFANA_DB}"; then
+    echo "Grafana: Data source ${INFLUXDB_GRAFANA_DB} already exists"
+    install_plugins
+  else
+    echo "Grafana: Data source ${INFLUXDB_GRAFANA_DB} is being created"
+    echo
+    if grafana_create_data_source "${INFLUXDB_GRAFANA_DB}"; then
+      echo "Grafana: Data source ${INFLUXDB_GRAFANA_DB} created"
+      install_plugins
+    else
+      echo "Grafana: Data source ${INFLUXDB_GRAFANA_DB} could not be created"
+      echo
+      install_plugins
+    fi
+  fi
+}
+
+function install_plugins {
+  echo "=> Installing some maybe useful plugins..."
+grafana-cli plugins install grafana-clock-panel 
+grafana-cli plugins install grafana-piechart-panel 
+grafana-cli plugins install mtanda-histogram-panel
+  
+echo "=> Finished installing plugins..."
+}
+
+function die {
+   /etc/init.d/grafana-server stop
+   exit 0
+}
+
+function setup {
+  /etc/init.d/grafana-server start
+  setup_grafana "${INFLUXDB_GRAFANA_DB}"
+  #fill_influx_sample_data
+  die
+}
+
+function fill_influxdb_sample_data {
+  for _ in $(seq 3600); do
+    curl -X POST \
+      "http://localhost:8086/db/${INFLUXDB_GRAFANA_DB}/series?u=${1}&p=${1}" \
+      -d "[{\"name\":\"data\",\"columns\":[\"foo\",\"bar\"],\"points\":[[$((RANDOM%200+100)),$((RANDOM%300+50))]]}]";
+    sleep 1;
+  done
+}
+
+  setup


### PR DESCRIPTION
@samuelebistoletti I see you already upgraded some of the components to the recent versions. I was already doing the same thing. 

However, I think having a great Grafana stack would be more useful with a default datasource and dashboard. Grafana 3.x also has great plugins and I think most of the dashboards use some basic ones (I have added clock, histogram and piechart). 

Some pending challenges:
- adding the influxdb datasource to Grafana using `curl` before the `grafana.ini` file is loaded ( to bypass authentication issues) completes successfully but isn't loaded when Grafana is started. Perhaps you have more experience here can come up with a fix? Check `scripts/setup_grafana.sh`. The dashboard loads fine.
- Would be nice to make the addition of plugins and or dashboard at "runtime". First thing that comes to mind is using environment variables i.e. `docker run -e GRAFANA_PLUGIN... -e GRAFANA_DASHBOARD...`  but would like to get your input on this.
- Would also be nice to prepopulate the influxdb with some measurements. I have a stub in `scripts/setup_grafana.sh`

Let me know your thoughts and if you agree with the development path :)

Cheers
