### PR TITLE
Only set ulimit for influx if necessary

### DIFF
--- a/influxdb/init.sh
+++ b/influxdb/init.sh
@@ -109,12 +109,14 @@ function start() {
         fi
     fi
 
-    # Bump the file limits, before launching the daemon. These will
+    # Bump the file limits, if required, before launching the daemon. These will
     # carry over to launched processes.
-    ulimit -n $OPEN_FILE_LIMIT
-    if [ $? -ne 0 ]; then
-        log_failure_msg "Unable to set ulimit to $OPEN_FILE_LIMIT"
-        exit 1
+    if [ `ulimit -n` -lt $OPEN_FILE_LIMIT ]; then
+        ulimit -n $OPEN_FILE_LIMIT
+        if [ $? -ne 0 ]; then
+            log_failure_msg "Unable to set ulimit to $OPEN_FILE_LIMIT"
+            exit 1
+        fi
     fi
 
     # Launch process


### PR DESCRIPTION
Setting the ulimit in a container requires permissions and some container platforms (e.g. AWS ECS) don't give those permissions by default. Therefore the script has been modified to only try and set the ulimit if it is lower than necessary. That allows the ulimit to be set to the right amount outside the container, and the permissions don't have to be given to the container