### PR TITLE
Enable support for tags in Datadog format

### DIFF
--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -1970,7 +1970,7 @@
 
    ## Parses tags in the datadog statsd format
    ## http://docs.datadoghq.com/guides/dogstatsd/
-   parse_data_dog_tags = false
+   parse_data_dog_tags = true
 
    ## Statsd data translation templates, more info can be read here:
    ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md#graphite


### PR DESCRIPTION
A lot StatsD libraries out there support sending tags to StatsD but using the Datadog format, luckily Telegraf is able to parse them by simply by enabling this functionality.