### PR TITLE
add curl to grafana image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ First download and install the latest available version of Docker Compose <https
 In order to start the service the first time launch:
 
 ```sh
-COMPOSE_PROFILES=grafana,telegraf docker-compose up -d
+COMPOSE_PROFILES=grafana,telegraf docker-compose up -d --build
 ```
 
 You can replace `COMPOSE_PROFILES=grafana,telegraf` with the desired profiles to launch, you can launch only InfluxDB (default with no profiles).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,11 @@ services:
       - postgres_data:/bitnami/postgresql
 
   grafana:
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
+      args:
+        - GRAFANA_VERSION=${GRAFANA_VERSION:-latest}
     container_name: dsig-grafana
     image: grafana/grafana-enterprise:${GRAFANA_VERSION}
     profiles: ["grafana"]

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,5 @@
+ARG GRAFANA_VERSION
+
+FROM grafana/grafana-enterprise:${GRAFANA_VERSION}
+USER root
+RUN apk --no-cache add curl


### PR DESCRIPTION
Curl not available in docker grafana image and container state up, but unhealthy.